### PR TITLE
Resolvendo o primeiro de muitos erros de compilação

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,19 +1,19 @@
 all: game executa limpa
 
 game: main.o game.o sprite.o state.o
-	g++ main.o game.o sprite.o state.o -o game -std=c++11
+	g++ main.o game.o sprite.o state.o -o game -std=c++11 -Wall -pedantic
 
 main.o: main.cpp game.cpp game.hpp
-	g++ main.cpp -std=c++11 -lSDL2 -lSDL2_image
+	g++ main.cpp -std=c++11 -lSDL2 -lSDL2_image -Wall -pedantic -c
 
 game.o: game.cpp  game.hpp state.cpp state.hpp
-	g++ game.cpp -std=c++11 -lSDL2 -lSDL2_image
+	g++ game.cpp -std=c++11 -lSDL2 -lSDL2_image -Wall -pedantic -c
 	
 sprite.o:sprite.cpp sprite.hpp
-	g++ sprite.cpp -std=c++11 -lSDL2 -lSDL2_image
+	g++ sprite.cpp -std=c++11 -lSDL2 -lSDL2_image -Wall -pedantic -c
 
 state.o: state.cpp state.hpp sprite.cpp sprite.hpp
-	g++ state.cpp -std=c++11 -lSDL2 -lSDL2_image
+	g++ state.cpp -std=c++11 -lSDL2 -lSDL2_image -Wall -pedantic -c
 	
 executa:
 	./game


### PR DESCRIPTION
Você esqueceu de colocar a diretiva -c na hora de gerar os arquivos objetos. Lembre-se que o a diretiva -o apenas nomeia o arquivo de saída, não altera em NADA a compilação.